### PR TITLE
Endpoint Budget Threshold

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -446,6 +446,12 @@ config_string(
 )
 
 config_option(
+    KernelEPbudgetThreshold EP_THRESHOLD "Enable endpoint budget threshold support."
+    DEFAULT ON
+    DEPENDS "KernelIsMCS; NOT KernelVerificationBuild"
+)
+
+config_option(
     KernelClz32 CLZ_32 "Define a __clzsi2 function to count leading zeros for uint32_t arguments. \
                         Only needed on platforms which lack a builtin instruction." DEFAULT OFF
 )

--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -198,3 +198,8 @@ void refill_budget_check(ticks_t used);
  */
 void refill_unblock_check(sched_context_t *sc);
 
+/*
+ * Mering refills until the head refill has at least `min_budget` budget.
+ */
+void refill_merge_until_budget(sched_context_t *sc, ticks_t min_budget);
+

--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -201,5 +201,5 @@ void refill_unblock_check(sched_context_t *sc);
 /*
  * Mering refills until the head refill has at least `min_budget` budget.
  */
-void refill_merge_until_budget(sched_context_t *sc, ticks_t min_budget);
+bool_t refill_merge_until_budget(sched_context_t *sc, ticks_t min_budget);
 

--- a/include/object/endpoint.h
+++ b/include/object/endpoint.h
@@ -52,7 +52,7 @@ static inline ticks_t ep_get_budget_threshold(endpoint_t *ep)
     uint16_t low = endpoint_ptr_get_budget_threshold_low(ep);
     uint16_t high = endpoint_ptr_get_budget_threshold_high(ep);
 
-    return (high << 16) | low;
+    return ((ticks_t)high << 16) | low;
 }
 
 static inline void ep_set_budget_threshold(endpoint_t *ep, uint32_t threshold)

--- a/include/object/endpoint.h
+++ b/include/object/endpoint.h
@@ -43,3 +43,26 @@ void cancelBadgedSends(endpoint_t *epptr, word_t badge);
 void replyFromKernel_error(tcb_t *thread);
 void replyFromKernel_success_empty(tcb_t *thread);
 
+#ifdef CONFIG_EP_THRESHOLD
+exception_t ep_decodeSetBudgetThreshold(word_t invLabel, word_t length, word_t *buffer);
+
+/* Needed because fields can't cross word boundaries in bf... */
+static inline ticks_t ep_get_budget_threshold(endpoint_t *ep)
+{
+    uint16_t low = endpoint_ptr_get_budget_threshold_low(ep);
+    uint16_t high = endpoint_ptr_get_budget_threshold_high(ep);
+
+    return (high << 16) | low;
+}
+
+static inline void ep_set_budget_threshold(endpoint_t *ep, uint32_t threshold)
+{
+    uint16_t low = threshold & 0xff;
+    uint16_t high = (threshold >> 16) & 0xff;
+
+    endpoint_ptr_set_budget_threshold_high(ep, high);
+    endpoint_ptr_set_budget_threshold_low(ep, low);
+}
+
+#endif
+

--- a/include/object/reply.h
+++ b/include/object/reply.h
@@ -35,3 +35,4 @@ void reply_remove(reply_t *reply, tcb_t *tcb);
 /* Remove a specific tcb, and the reply it is blocking on, from the call stack */
 void reply_remove_tcb(tcb_t *tcb);
 
+exception_t decodeReplyInvocation(word_t label, word_t length, word_t *buffer);

--- a/include/object/structures_32.bf
+++ b/include/object/structures_32.bf
@@ -146,7 +146,13 @@ block sched_control_cap {
 
 -- Endpoint: size = 16 bytes
 block endpoint {
+#ifdef CONFIG_KERNEL_MCS
+    field budget_threshold_low 16
+    field budget_threshold_high 16
+    padding 32
+#else
     padding 64
+#endif
 
     field_high epQueue_head 28
     padding 4

--- a/include/object/structures_64.bf
+++ b/include/object/structures_64.bf
@@ -202,13 +202,17 @@ block sched_control_cap {
 
 -- Endpoint: size = 16 bytes
 block endpoint {
-    field epQueue_head 64
-
 #if BF_CANONICAL_RANGE == 48
-    padding 16
+    field budget_threshold_low 16
+    field_high epQueue_head 48
+    field budget_threshold_high 16
     field_high epQueue_tail 46
 #elif BF_CANONICAL_RANGE == 39
-    padding 25
+    field budget_threshold_low 16
+    padding 9
+    field_high epQueue_head 39
+    field budget_threshold_high 16
+    padding 9
     field_high epQueue_tail 37
 #else
 #error "Unspecified canonical address range"

--- a/libsel4/include/interfaces/object-api.xml
+++ b/libsel4/include/interfaces/object-api.xml
@@ -1544,4 +1544,45 @@
         </method>
     </interface>
 
+    <interface name="seL4_ReplyCap" manual_name="Reply" cap_description="CPtr to a Reply object.">
+        <method id="EndpointSetBudgetThreshold" name="SetBudgetThreshold" manual_label="ep_set_budget_threshold">
+            <condition><config var="CONFIG_KERNEL_MCS"/></condition>
+            <brief>
+                Sets the budget threshold value of an endpoint.
+            </brief>
+            <description>
+                This configures the minimum amount of budget sporadic threads need to have before calls
+                to the endpoint will proceed. If, at the time of the call, there is not enough remaining
+                budget to pass the threshold, the caller will either timeout fault or be postponed till
+                it has enough budget. Once the caller has enough budget, the call will proceed normally.
+
+                This can be used to avoid running out of budget during calls, ensuring that passive
+                servers do not timeout fault or get postponed, as long as they stay within the threshold
+                budget.
+
+                Round-robin callers are not checked because they cannot run out of budget.
+
+                This is a Reply invocation as for endpoints it would be indistinguishable from IPC calls.
+            </description>
+            <return><errorenumdesc/></return>
+            <param dir="in" name="endpoint" type="seL4_CPtr" description="CPtr to an Endpoint with Read permission."/>
+            <param dir="in" name="threshold" type="seL4_Time" description="Value of the budget threshold to set."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    <texttt text="endpoint"/> does not have Read right.
+                    Or, <texttt text="endpoint"/> is not valid or the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="threshold"/> is too large.
+                </description>
+            </error>
+        </method>
+    </interface>
 </api>

--- a/libsel4/include/sel4/types.h
+++ b/libsel4/include/sel4/types.h
@@ -40,6 +40,7 @@ typedef seL4_CPtr seL4_Untyped;
 typedef seL4_CPtr seL4_DomainSet;
 typedef seL4_CPtr seL4_SchedContext;
 typedef seL4_CPtr seL4_SchedControl;
+typedef seL4_CPtr seL4_ReplyCap;
 
 typedef seL4_Uint64 seL4_Time;
 

--- a/libsel4/tools/syscall_stub_gen.py
+++ b/libsel4/tools/syscall_stub_gen.py
@@ -256,6 +256,7 @@ def init_data_types(wordsize):
         CapType("seL4_DomainSet", wordsize),
         CapType("seL4_SchedContext", wordsize),
         CapType("seL4_SchedControl", wordsize),
+        CapType("seL4_ReplyCap", wordsize),
     ]
 
     return types

--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -347,6 +347,13 @@ void refill_budget_check(ticks_t usage)
     REFILL_SANITY_END(sc);
 }
 
+void refill_merge_until_budget(sched_context_t *sc, ticks_t min_budget)
+{
+    while (refill_capacity(sc, 0) < min_budget) {
+        merge_nonoverlapping_head_refill(sc);
+    }
+}
+
 static inline void merge_overlapping_head_refill(sched_context_t *sc)
 {
     refill_t old_head = refill_pop_head(sc);

--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -347,11 +347,15 @@ void refill_budget_check(ticks_t usage)
     REFILL_SANITY_END(sc);
 }
 
-void refill_merge_until_budget(sched_context_t *sc, ticks_t min_budget)
+bool_t refill_merge_until_budget(sched_context_t *sc, ticks_t min_budget)
 {
     while (refill_capacity(sc, 0) < min_budget) {
+        if (refill_single(sc)) {
+            return false;
+        }
         merge_nonoverlapping_head_refill(sc);
     }
+    return true;
 }
 
 static inline void merge_overlapping_head_refill(sched_context_t *sc)

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -649,8 +649,6 @@ void chargeBudget(ticks_t consumed, bool_t canTimeoutFault)
     if (likely(isSchedulable(NODE_STATE(ksCurThread)))) {
         assert(NODE_STATE(ksCurThread)->tcbSchedContext == NODE_STATE(ksCurSC));
         endTimeslice(canTimeoutFault);
-        rescheduleRequired();
-        NODE_STATE(ksReprogram) = true;
     }
 }
 
@@ -670,6 +668,8 @@ void endTimeslice(bool_t can_timeout_fault)
         /* postpone until ready */
         postpone(NODE_STATE(ksCurSC));
     }
+    rescheduleRequired();
+    NODE_STATE(ksReprogram) = true;
 }
 #else
 

--- a/src/object/reply.c
+++ b/src/object/reply.c
@@ -134,3 +134,19 @@ void reply_remove_tcb(tcb_t *tcb)
     reply->replyNext = call_stack_new(0, false);
     reply_unlink(reply, tcb);
 }
+
+#ifdef CONFIG_EP_THRESHOLD
+#include <object/endpoint.h>
+
+NO_INLINE exception_t decodeReplyInvocation(word_t label, word_t length, word_t *buffer)
+{
+    switch (label) {
+    case EndpointSetBudgetThreshold:
+        return ep_decodeSetBudgetThreshold(length, length, buffer);
+    default:
+        userError("Reply invocation: Illegal operation attempted.");
+        current_syscall_error.type = seL4_IllegalOperation;
+        return EXCEPTION_SYSCALL_ERROR;
+    }
+}
+#endif


### PR DESCRIPTION
Work in progress, cleaner implementation of the work done by @Yermin9. See
- https://sel4.atlassian.net/browse/RFC-14
- https://github.com/seL4/rfcs/pull/24
- https://github.com/Yermin9/seL4/pull/6

Issues that make the implementation complicated:

- We want the task to be restarted when ThreadState_Restart, but
  current code assumes that means something else. Commit https://github.com/Indanz/seL4/commit/8ae457a4d40b8360404fd0c89bb042631e0140e0
  is one possible work-around and something I think we want anyway.

  Another solution would be to clean up the threadstate code so that
  ThreadState_Restart will be honoured. Whatever is done, it will
  cause changes to the current code and add verification work.

- There is no way to do endpoint invocations. Current work-around
  is to make it a reply invocation at the cost of one extra if-check
  in the reply handling slow path. An alternative is to make it a
  CNode operation like Yermin9 did, but that's even uglier of a
  solution, as it requires too much permissions. Now if a server
  can receive on the endpoint, it can also set the budget threshold,
  which makes sense considering the server has to be trusted to reply
  eventually.

- The bitfield generator can't deal with fields spread over multiple
  words, forcing us to split the field into a high and a low one.
  Solution would be to fix the generator to support this, but I
  don't know how to do that for the generated proofs. Only 64-bit
  has this problem, but to reduce differences between 32 and 64-bits
  the code is the same.

TODO:
- Check details (exact behaviour on block, !canDonate etc.)
- Write tests.
- Bechmark.
